### PR TITLE
feat: 할 일 생성/조회 간 오늘 할 일 여부 추가

### DIFF
--- a/app/src/todos/models.py
+++ b/app/src/todos/models.py
@@ -13,3 +13,4 @@ class Todo(Base):
     task = Column(String(255))
     due_date = Column(Date)
     user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
+    today = Column(Boolean, default=True)

--- a/app/src/todos/repository.py
+++ b/app/src/todos/repository.py
@@ -56,8 +56,13 @@ class TodoRepository(TodoRepositoryInterface):
         )
 
     # READ: all todos
-    def get_all_todos(self, user_id: int) -> list[Todo] | None:
-        return self.db.query(Todo).filter(Todo.user_id == user_id).all()
+    def get_all_todos(self, user_id: int, today: bool | None) -> list[Todo] | None:
+        # 오늘 할 일 여부와 상관 없이 USER_ID의 모든 Todo 반환
+        if today is None:
+            return self.db.query(Todo).filter_by(user_id=user_id).all()
+        
+        # 오늘 할 일 여부에 따른 USER_ID의 Todo 반환
+        return self.db.query(Todo).filter_by(user_id=user_id, today=today).all()
 
     # CREATE: single todo
     def create_todo(self, todo: TodoItem, user_id: int) -> Todo:

--- a/app/src/todos/router.py
+++ b/app/src/todos/router.py
@@ -1,10 +1,10 @@
-
 from auth.dependencies import get_current_user
 from auth.models import User
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, status, Query
 from todos.dependencies import get_todo_service
 from todos.schemas import TodoCompletedState, TodoItem, TodoResponse
 from todos.service import TodoService
+from typing import Optional
 
 router = APIRouter(prefix="/todos", tags=["Todos"])
 
@@ -31,9 +31,13 @@ def create_todo_item(
 )
 def read_todo_list(
     service: TodoService = Depends(get_todo_service),
-    user: User = Depends(get_current_user)
+    user: User = Depends(get_current_user),
+    today: Optional[bool] = Query(
+        default=None,
+        description="오늘 할 일만: true, 오늘 할 일이 아닌 것만: false, 전체: 생략"
+    )
 ):
-    return service.get_all_todos(user)
+    return service.get_all_todos(user, today)
 
 
 # 하나의 todo만 불러오기

--- a/app/src/todos/schemas.py
+++ b/app/src/todos/schemas.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 class TodoItem(BaseModel):
     task: str
     due_date: Optional[date] = None
+    today: bool
 
 
 # Request
@@ -23,6 +24,7 @@ class TodoResponse(BaseModel):
     task: str
     due_date: Optional[date]
     is_done: bool
+    today: bool
 
     class Config:
         from_attributes = True  # (deprecated) orm_mode

--- a/app/src/todos/service.py
+++ b/app/src/todos/service.py
@@ -17,8 +17,8 @@ class TodoService:
         return self.repository.create_todo(todo, user.id)
     
 
-    def get_all_todos(self, user: User) -> list[Todo]:
-        return self.repository.get_all_todos(user.id)
+    def get_all_todos(self, user: User, today: bool | None) -> list[Todo]:
+        return self.repository.get_all_todos(user.id, today)
     
 
     def get_todo_by_id(self, id: int, user: User) -> Todo:


### PR DESCRIPTION
feat: 할 일 생성/조회 간 오늘 할 일 여부 추가

- Todo Model 및 응답 스키마에 'today' 속성 추가

`create_todo_item()` 
: 새로운 todo 생성 시 today(bool) 여부 포함 필수

`read_todo_list()` 
query param: 
- true:오늘 할 일
- false: 오늘 할 일이 아님
- 생략: 모든 todo
